### PR TITLE
#26 - Added sys.exit call

### DIFF
--- a/syphon/__main__.py
+++ b/syphon/__main__.py
@@ -11,7 +11,7 @@ def bootstrap(args=None):
     if args is None:
         args = argv[1:]
     try:
-        _main(args)
+        exit(_main(args))
     except KeyboardInterrupt:
         raise SystemExit(2)
 


### PR DESCRIPTION
Wrapped bootstrap's call to `_main` within `sys.exit`